### PR TITLE
Update propagateSwipe to allow onSwipeComplete

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -322,6 +322,15 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           animEvt = this.createAnimationEventForSwipe();
           return shouldSetPanResponder;
         }
+        this.currentSwipingDirection = this.getSwipingDirection(gestureState);
+        animEvt = this.createAnimationEventForSwipe();
+        const accDistance = this.getAccDistancePerDirection(gestureState);
+        if (accDistance > this.props.swipeThreshold &&
+            this.isSwipeDirectionAllowed(gestureState)) {
+            if (this.props.onSwipeComplete) {
+                return true;
+            }
+        }
 
         return false;
       },


### PR DESCRIPTION
# Overview
Currently when you use propagateSwipe, you cannot perform an onSwipeComplete command. I have added code that allows for a user to perform onSwipeComplete when propagateSwipe is true.
