### PR TITLE
Fix velocity on swipe release

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -431,6 +431,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
         Animated.spring(this.state.pan!, {
           toValue: {x: 0, y: 0},
+          velocity: Math.max(gestureState.vx, gestureState.vy),
           bounciness: 0,
           useNativeDriver: false,
         }).start();


### PR DESCRIPTION
# Overview

Currently when we swipe the modal (in a quick fashion) and release, the modal stops, then keeps on moving to eventually completely close. I would like to smoothen the effect to make it look like the initial inertia of the swipe is preserved on the automatic close modal animation (equivalent to `isVisible` changes to `true`)

# Test Plan

For now I only added a single modification to preserve velocity. I've only tested it for swiping downward. The animation is not perfect yet but I'll keep on digging to find the right balance. 

I just opened this PR in case someone has some idea on how to test/improve things (do you have working example for me to try?). 
