### PR TITLE
Register an interaction on modal animation

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   DeviceEventEmitter,
   Dimensions,
+  InteractionManager,
   KeyboardAvoidingView,
   Modal,
   PanResponder,
@@ -584,10 +585,12 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     if (this.contentRef) {
       this.props.onModalWillShow && this.props.onModalWillShow();
+      const interactionHandle = InteractionManager.createInteractionHandle();
       this.contentRef
         .animate(this.animationIn, this.props.animationInTiming)
         .then(() => {
           this.isTransitioning = false;
+          InteractionManager.clearInteractionHandle(interactionHandle);
           if (!this.props.isVisible) {
             this.close();
           } else {
@@ -626,10 +629,12 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     if (this.contentRef) {
       this.props.onModalWillHide && this.props.onModalWillHide();
+      const interactionHandle = InteractionManager.createInteractionHandle();
       this.contentRef
         .animate(animationOut, this.props.animationOutTiming)
         .then(() => {
           this.isTransitioning = false;
+          InteractionManager.clearInteractionHandle(interactionHandle);
           if (this.props.isVisible) {
             this.open();
           } else {


### PR DESCRIPTION
# Overview

Allow modal open/close interactions to be tracked through the interaction manager

# Test Plan

I verified using a project for work (sorry for the lack of screenshots/videos, but you know how that goes). This project required a callback to be called after a modal close animation completed and the included code was able to fix the bug I have been fighting for the better part of the afternoon while allowing me to avoid an ugly hack using `setTimeout`. 
