### PR TITLE
feat: Add panResponderThreshold to props (#469)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ function WrapperComponent() {
   return (
     <View>
       <Modal>
-        <View style={{ flex: 1 }}>
+        <View style={{flex: 1}}>
           <Text>I am the modal content!</Text>
         </View>
       </Modal>
     </View>
-  )
+  );
 }
 ```
 
@@ -62,12 +62,12 @@ function WrapperComponent() {
   return (
     <View>
       <Modal isVisible={true}>
-        <View style={{ flex: 1 }}>
+        <View style={{flex: 1}}>
           <Text>I am the modal content!</Text>
         </View>
       </Modal>
     </View>
-  )
+  );
 }
 ```
 
@@ -87,24 +87,24 @@ import Modal from 'react-native-modal';
 
 function ModalTester() {
   const [isModalVisible, setModalVisible] = useState(false);
-  
+
   const toggleModal = () => {
     setModalVisible(!isModalVisible);
   };
 
-    return (
-      <View style={{flex: 1}}>
-        <Button title="Show modal" onPress={toggleModal} />
+  return (
+    <View style={{flex: 1}}>
+      <Button title="Show modal" onPress={toggleModal} />
 
-        <Modal isVisible={isModalVisible}>
-          <View style={{flex: 1}}>
-            <Text>Hello!</Text>
+      <Modal isVisible={isModalVisible}>
+        <View style={{flex: 1}}>
+          <Text>Hello!</Text>
 
-            <Button title="Hide modal" onPress={toggleModal} />
-          </View>
-        </Modal>
-      </View>
-    );
+          <Button title="Hide modal" onPress={toggleModal} />
+        </View>
+      </Modal>
+    </View>
+  );
 }
 
 export default ModalTester;
@@ -142,6 +142,7 @@ For a more complex example take a look at the `/example` directory.
 | onSwipeMove                    | func             | (percentageShown) => null      | Called on each swipe event                                                                                                                 |
 | onSwipeComplete                | func             | ({ swipingDirection }) => null | Called when the `swipeThreshold` has been reached                                                                                          |
 | onSwipeCancel                  | func             | () => null                     | Called when the `swipeThreshold` has not been reached                                                                                      |
+| panResponderThreshold          | number           | 4                              | The threshold for when the panResponder should pick up swipe events                                                                        |
 | scrollOffset                   | number           | 0                              | When > 0, disables swipe-to-close, in order to implement scrollable content                                                                |
 | scrollOffsetMax                | number           | 0                              | Used to implement overscroll feel when content is scrollable. See `/example` directory                                                     |
 | scrollTo                       | func             | null                           | Used to implement scrollable modal. See `/example` directory for reference on how to use it                                                |
@@ -168,10 +169,13 @@ If you're experiencing this issue, you'll need to install [`react-native-extra-d
 Then, provide the real window height (obtained from `react-native-extra-dimensions-android`) to the modal:
 
 ```javascript
-const deviceWidth = Dimensions.get("window").width;
-const deviceHeight = Platform.OS === "ios"
-  ? Dimensions.get("window").height
-  : require("react-native-extra-dimensions-android").get("REAL_WINDOW_HEIGHT");
+const deviceWidth = Dimensions.get('window').width;
+const deviceHeight =
+  Platform.OS === 'ios'
+    ? Dimensions.get('window').height
+    : require('react-native-extra-dimensions-android').get(
+        'REAL_WINDOW_HEIGHT',
+      );
 
 function WrapperComponent() {
   const [isModalVisible, setModalVisible] = useState(true);
@@ -180,13 +184,12 @@ function WrapperComponent() {
     <Modal
       isVisible={isModalVisible}
       deviceWidth={deviceWidth}
-      deviceHeight={deviceHeight}
-    >
-      <View style={{ flex: 1 }}>
+      deviceHeight={deviceHeight}>
+      <View style={{flex: 1}}>
         <Text>I am the modal content!</Text>
       </View>
     </Modal>
-  )
+  );
 }
 ```
 
@@ -283,9 +286,7 @@ Also, some users have noticed that setting backdropTransitionOutTiming={0} can f
 You need to specify the size of your custom backdrop component. You can also make it expand to fill the entire screen by adding a `flex: 1` to its style:
 
 ```javascript
-<Modal
-  isVisible={isModalVisible}
-  customBackdrop={<View style={{flex: 1}} />}>
+<Modal isVisible={isModalVisible} customBackdrop={<View style={{flex: 1}} />}>
   <View style={{flex: 1}}>
     <Text>I am the modal content!</Text>
   </View>

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -92,6 +92,7 @@ export interface ModalProps extends ViewProps {
   onModalWillHide: () => void;
   onBackButtonPress: () => void;
   onBackdropPress: () => void;
+  panResponderThreshold: number;
   swipeThreshold: number;
   scrollTo: OrNull<(e: any) => void>;
   scrollOffset: number;
@@ -132,6 +133,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     onModalWillHide: PropTypes.func,
     onBackButtonPress: PropTypes.func,
     onBackdropPress: PropTypes.func,
+    panResponderThreshold: PropTypes.number,
     onSwipeStart: PropTypes.func,
     onSwipeMove: PropTypes.func,
     onSwipeComplete: PropTypes.func,
@@ -184,6 +186,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     onModalWillHide: () => null,
     onBackdropPress: () => null,
     onBackButtonPress: () => null,
+    panResponderThreshold: 4,
     swipeThreshold: 100,
 
     scrollTo: null,
@@ -266,7 +269,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   }
 
   componentWillUnmount() {
-    BackHandler.removeEventListener('hardwareBackPress', this.onBackButtonPress);
+    BackHandler.removeEventListener(
+      'hardwareBackPress',
+      this.onBackButtonPress,
+    );
     DeviceEventEmitter.removeListener(
       'didUpdateDimensions',
       this.handleDimensionsUpdate,
@@ -308,11 +314,11 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   getDeviceWidth = () => this.props.deviceWidth || this.state.deviceWidth;
   onBackButtonPress = () => {
     if (this.props.onBackButtonPress && this.props.isVisible) {
-      this.props.onBackButtonPress()
-      return true
+      this.props.onBackButtonPress();
+      return true;
     }
-    return false
-  }  
+    return false;
+  };
   buildPanResponder = () => {
     let animEvt: OrNull<AnimationEvent> = null;
 
@@ -323,10 +329,13 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         if (!this.props.propagateSwipe) {
           // The number "4" is just a good tradeoff to make the panResponder
           // work correctly even when the modal has touchable buttons.
+          // However, if you want to overwrite this and choose for yourself,
+          // set panResponderThreshold in the props.
           // For reference:
           // https://github.com/react-native-community/react-native-modal/pull/197
           const shouldSetPanResponder =
-            Math.abs(gestureState.dx) >= 4 || Math.abs(gestureState.dy) >= 4;
+            Math.abs(gestureState.dx) >= this.props.panResponderThreshold ||
+            Math.abs(gestureState.dy) >= this.props.panResponderThreshold;
           if (shouldSetPanResponder && this.props.onSwipeStart) {
             this.props.onSwipeStart();
           }


### PR DESCRIPTION
# Overview

A variable in the code is hardcoded when it really should be configurable if the developer wishes.

# Test Plan

Fire up a modal and make sure you can still swipe it closed.

#### Note - all the additional formatting fixes are due to the husky pre-commit hooks (from the master branch) auto-fixing missing semi-colons and indenting when I committed. My understanding is the maintainers want it in there to make sure commits are "pretty". If you guys don't want it, please update the master branch and remove it so developers trying to contribute don't get confused by what's going on. Then I'll refork, make my changes, and re-commit.