### PR TITLE
Allow propagateSwipe to be a function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
   Direction,
   PresentationStyle,
   OnOrientationChange,
+  GestureResponderEvent,
 } from './types';
 
 export default ReactNativeModal;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import {Animation, CustomAnimation} from 'react-native-animatable';
-import {NativeSyntheticEvent} from 'react-native';
+import {NativeSyntheticEvent, NativeTouchEvent} from 'react-native';
 
 export type OrNull<T> = null | T;
 
@@ -26,3 +26,6 @@ export type PresentationStyle =
 export type OnOrientationChange = (
   orientation: NativeSyntheticEvent<any>,
 ) => void;
+
+export interface GestureResponderEvent
+  extends NativeSyntheticEvent<NativeTouchEvent> {}


### PR DESCRIPTION
# Overview

I need to be able to avoid propagating swipe when certain elements are touched. They can be read through `event._targetInst` but that requires exposing `event`. I tried to keep things backwards compatible -`propagateSwipe` can be a boolean or callback.

Example use case: Yelp modal overlaying the map view. It has filter buttons in the header area. You can still swipe the modal when the touch begins on the button.

# Test Plan

`npm test`
