### PR TITLE
Fixes function props types

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -610,7 +610,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (!this.props.isVisible) {
             this.close();
           } else {
-            this.props.onModalShow!();
+            this.props.onModalShow();
           }
         });
     }
@@ -664,7 +664,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
                     isVisible: false,
                   },
                   () => {
-                    this.props.onModalHide!();
+                    this.props.onModalHide();
                   },
                 );
               },

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -80,6 +80,12 @@ const defaultProps = {
   panResponderThreshold: 4,
   swipeThreshold: 100,
 
+  onModalShow: (() => null) as () => void,
+  onModalWillShow: (() => null) as () => void,
+  onModalHide: (() => null) as () => void,
+  onModalWillHide: (() => null) as () => void,
+  onBackdropPress: (() => null) as () => void,
+  onBackButtonPress: (() => null) as () => void,
   scrollTo: null as OrNull<(e: any) => void>,
   scrollOffset: 0,
   scrollOffsetMax: 0,
@@ -108,12 +114,6 @@ export type ModalProps = ViewProps & {
   presentationStyle?: PresentationStyle;
 
   // Default ModalProps Provided
-  onModalShow?: () => void;
-  onModalWillShow?: () => void;
-  onModalHide?: () => void;
-  onModalWillHide?: () => void;
-  onBackdropPress?: () => void;
-  onBackButtonPress?: () => void;
   useNativeDriverForBackdrop?: boolean;
 } & typeof defaultProps;
 

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -250,15 +250,15 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     this.animationIn = animationIn;
     this.animationOut = animationOut;
 
-    this.scrollOffset = this.props?.scrollOffset || defaultProps.scrollOffset;
+    this.scrollOffset = this.props.scrollOffset || defaultProps.scrollOffset;
     this.panResponderThreshold =
-      this.props?.panResponderThreshold || defaultProps.panResponderThreshold;
+      this.props.panResponderThreshold || defaultProps.panResponderThreshold;
     this.scrollOffsetMax =
-      this.props?.scrollOffsetMax ?? defaultProps.scrollOffsetMax;
+      this.props.scrollOffsetMax ?? defaultProps.scrollOffsetMax;
     this.swipeThreshold =
-      this.props?.swipeThreshold ?? defaultProps.swipeThreshold;
-    this.onModalShow = this.props?.onModalShow ?? defaultProps.onModalShow;
-    this.onModalHide = this.props?.onModalHide ?? defaultProps.onModalHide;
+      this.props.swipeThreshold ?? defaultProps.swipeThreshold;
+    this.onModalShow = this.props.onModalShow ?? defaultProps.onModalShow;
+    this.onModalHide = this.props.onModalHide ?? defaultProps.onModalHide;
 
     if (this.state.isSwipeable) {
       this.state = {
@@ -432,7 +432,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           this.backdropRef &&
             this.backdropRef.transitionTo({
               opacity:
-                (this.props?.backdropOpacity ?? defaultProps.backdropOpacity) *
+                (this.props.backdropOpacity ?? defaultProps.backdropOpacity) *
                 newOpacityFactor,
             });
 

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -74,49 +74,84 @@ export interface ModalProps extends ViewProps {
   presentationStyle?: PresentationStyle;
 
   // Default ModalProps Provided
-  animationIn: Animation | CustomAnimation;
-  animationInTiming: number;
-  animationOut: Animation | CustomAnimation;
-  animationOutTiming: number;
-  avoidKeyboard: boolean;
-  coverScreen: boolean;
-  hasBackdrop: boolean;
-  backdropColor: string;
-  backdropOpacity: number;
-  backdropTransitionInTiming: number;
-  backdropTransitionOutTiming: number;
-  customBackdrop: React.ReactNode;
-  useNativeDriver: boolean;
+  animationIn?: Animation | CustomAnimation;
+  animationInTiming?: number;
+  animationOut?: Animation | CustomAnimation;
+  animationOutTiming?: number;
+  avoidKeyboard?: boolean;
+  coverScreen?: boolean;
+  hasBackdrop?: boolean;
+  backdropColor?: string;
+  backdropOpacity?: number;
+  backdropTransitionInTiming?: number;
+  backdropTransitionOutTiming?: number;
+  customBackdrop?: React.ReactNode;
+  useNativeDriver?: boolean;
   useNativeDriverForBackdrop?: boolean;
-  deviceHeight: number;
-  deviceWidth: number;
-  hideModalContentWhileAnimating: boolean;
-  propagateSwipe:
+  deviceHeight?: number;
+  deviceWidth?: number;
+  hideModalContentWhileAnimating?: boolean;
+  propagateSwipe?:
     | boolean
     | ((
         event: GestureResponderEvent,
         gestureState: PanResponderGestureState,
       ) => boolean);
   isVisible: boolean;
-  onModalShow: () => void;
-  onModalWillShow: () => void;
-  onModalHide: () => void;
-  onModalWillHide: () => void;
-  onBackButtonPress: () => void;
-  onBackdropPress: () => void;
-  panResponderThreshold: number;
-  swipeThreshold: number;
-  scrollTo: OrNull<(e: any) => void>;
-  scrollOffset: number;
-  scrollOffsetMax: number;
-  scrollHorizontal: boolean;
+  onModalShow?: () => void;
+  onModalWillShow?: () => void;
+  onModalHide?: () => void;
+  onModalWillHide?: () => void;
+  onBackButtonPress?: () => void;
+  onBackdropPress?: () => void;
+  panResponderThreshold?: number;
+  swipeThreshold?: number;
+  scrollTo?: OrNull<(e: any) => void>;
+  scrollOffset?: number;
+  scrollOffsetMax?: number;
+  scrollHorizontal?: boolean;
   statusBarTranslucent?: boolean;
   supportedOrientations?: Orientation[];
 }
 
+const defaultProps = {
+  animationIn: 'slideInUp' as Animation,
+  animationInTiming: 300,
+  animationOut: 'slideOutDown' as Animation,
+  animationOutTiming: 300,
+  avoidKeyboard: false,
+  coverScreen: true,
+  hasBackdrop: true,
+  backdropColor: 'black',
+  backdropOpacity: 0.7,
+  backdropTransitionInTiming: 300,
+  backdropTransitionOutTiming: 300,
+  customBackdrop: null,
+  useNativeDriver: false,
+  deviceHeight: null,
+  deviceWidth: null,
+  hideModalContentWhileAnimating: false,
+  propagateSwipe: false,
+  isVisible: false,
+  onModalShow: () => null,
+  onModalWillShow: () => null,
+  onModalHide: () => null,
+  onModalWillHide: () => null,
+  onBackdropPress: () => null,
+  onBackButtonPress: () => null,
+  panResponderThreshold: 4,
+  swipeThreshold: 100,
+
+  scrollTo: null,
+  scrollOffset: 0,
+  scrollOffsetMax: 0,
+  scrollHorizontal: false,
+  supportedOrientations: ['portrait', 'landscape'],
+};
+
 const extractAnimationFromProps = (props: ModalProps) => ({
-  animationIn: props.animationIn,
-  animationOut: props.animationOut,
+  animationIn: props.animationIn ?? defaultProps.animationIn,
+  animationOut: props.animationOut ?? defaultProps.animationOut,
 });
 
 export class ReactNativeModal extends React.Component<ModalProps, State> {
@@ -173,40 +208,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     ),
   };
 
-  public static defaultProps = {
-    animationIn: 'slideInUp',
-    animationInTiming: 300,
-    animationOut: 'slideOutDown',
-    animationOutTiming: 300,
-    avoidKeyboard: false,
-    coverScreen: true,
-    hasBackdrop: true,
-    backdropColor: 'black',
-    backdropOpacity: 0.7,
-    backdropTransitionInTiming: 300,
-    backdropTransitionOutTiming: 300,
-    customBackdrop: null,
-    useNativeDriver: false,
-    deviceHeight: null,
-    deviceWidth: null,
-    hideModalContentWhileAnimating: false,
-    propagateSwipe: false,
-    isVisible: false,
-    onModalShow: () => null,
-    onModalWillShow: () => null,
-    onModalHide: () => null,
-    onModalWillHide: () => null,
-    onBackdropPress: () => null,
-    onBackButtonPress: () => null,
-    panResponderThreshold: 4,
-    swipeThreshold: 100,
-
-    scrollTo: null,
-    scrollOffset: 0,
-    scrollOffsetMax: 0,
-    scrollHorizontal: false,
-    supportedOrientations: ['portrait', 'landscape'],
-  };
+  public static defaultProps = defaultProps;
 
   // We use an internal state for keeping track of the modal visibility: this allows us to keep
   // the modal visible during the exit animation, even if the user has already change the
@@ -232,6 +234,13 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
 
+  scrollOffset: number;
+  panResponderThreshold: number;
+  scrollOffsetMax: number;
+  swipeThreshold: number;
+  onModalShow: () => void;
+  onModalHide: () => void;
+
   constructor(props: ModalProps) {
     super(props);
     const {animationIn, animationOut} = buildAnimations(
@@ -240,6 +249,16 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     this.animationIn = animationIn;
     this.animationOut = animationOut;
+
+    this.scrollOffset = this.props?.scrollOffset || defaultProps.scrollOffset;
+    this.panResponderThreshold =
+      this.props?.panResponderThreshold || defaultProps.panResponderThreshold;
+    this.scrollOffsetMax =
+      this.props?.scrollOffsetMax ?? defaultProps.scrollOffsetMax;
+    this.swipeThreshold =
+      this.props?.swipeThreshold ?? defaultProps.swipeThreshold;
+    this.onModalShow = this.props?.onModalShow ?? defaultProps.onModalShow;
+    this.onModalHide = this.props?.onModalHide ?? defaultProps.onModalHide;
 
     if (this.state.isSwipeable) {
       this.state = {
@@ -356,8 +375,8 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           // For reference:
           // https://github.com/react-native-community/react-native-modal/pull/197
           const shouldSetPanResponder =
-            Math.abs(gestureState.dx) >= this.props.panResponderThreshold ||
-            Math.abs(gestureState.dy) >= this.props.panResponderThreshold;
+            Math.abs(gestureState.dx) >= this.panResponderThreshold ||
+            Math.abs(gestureState.dy) >= this.panResponderThreshold;
           if (shouldSetPanResponder && this.props.onSwipeStart) {
             this.props.onSwipeStart(gestureState);
           }
@@ -380,7 +399,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           hasScrollableView &&
           this.shouldPropagateSwipe(e, gestureState) &&
           this.props.scrollTo &&
-          this.props.scrollOffset > 0
+          this.scrollOffset > 0
         ) {
           return false; // user needs to be able to scroll content back up
         }
@@ -412,7 +431,9 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
           this.backdropRef &&
             this.backdropRef.transitionTo({
-              opacity: this.props.backdropOpacity * newOpacityFactor,
+              opacity:
+                (this.props?.backdropOpacity ?? defaultProps.backdropOpacity) *
+                newOpacityFactor,
             });
 
           animEvt!(evt, gestureState);
@@ -424,15 +445,15 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (this.props.scrollTo) {
             if (this.props.scrollHorizontal) {
               let offsetX = -gestureState.dx;
-              if (offsetX > this.props.scrollOffsetMax) {
-                offsetX -= (offsetX - this.props.scrollOffsetMax) / 2;
+              if (offsetX > this.scrollOffsetMax) {
+                offsetX -= (offsetX - this.scrollOffsetMax) / 2;
               }
 
               this.props.scrollTo({x: offsetX, animated: false});
             } else {
               let offsetY = -gestureState.dy;
-              if (offsetY > this.props.scrollOffsetMax) {
-                offsetY -= (offsetY - this.props.scrollOffsetMax) / 2;
+              if (offsetY > this.scrollOffsetMax) {
+                offsetY -= (offsetY - this.scrollOffsetMax) / 2;
               }
 
               this.props.scrollTo({y: offsetY, animated: false});
@@ -444,7 +465,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         // Call the onSwipe prop if the threshold has been exceeded on the right direction
         const accDistance = this.getAccDistancePerDirection(gestureState);
         if (
-          accDistance > this.props.swipeThreshold &&
+          accDistance > this.swipeThreshold &&
           this.isSwipeDirectionAllowed(gestureState)
         ) {
           if (this.props.onSwipeComplete) {
@@ -483,7 +504,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         }).start();
 
         if (this.props.scrollTo) {
-          if (this.props.scrollOffset > this.props.scrollOffsetMax!) {
+          if (this.scrollOffset > this.scrollOffsetMax) {
             this.props.scrollTo({
               y: this.props.scrollOffsetMax,
               animated: true,
@@ -640,7 +661,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (!this.props.isVisible) {
             this.close();
           } else {
-            this.props.onModalShow();
+            this.onModalShow();
           }
         });
     }
@@ -694,7 +715,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
                     isVisible: false,
                   },
                   () => {
-                    this.props.onModalHide();
+                    this.onModalHide();
                   },
                 );
               },

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -234,13 +234,6 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
 
-  scrollOffset: number;
-  panResponderThreshold: number;
-  scrollOffsetMax: number;
-  swipeThreshold: number;
-  onModalShow: () => void;
-  onModalHide: () => void;
-
   constructor(props: ModalProps) {
     super(props);
     const {animationIn, animationOut} = buildAnimations(
@@ -249,16 +242,6 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     this.animationIn = animationIn;
     this.animationOut = animationOut;
-
-    this.scrollOffset = this.props.scrollOffset || defaultProps.scrollOffset;
-    this.panResponderThreshold =
-      this.props.panResponderThreshold || defaultProps.panResponderThreshold;
-    this.scrollOffsetMax =
-      this.props.scrollOffsetMax ?? defaultProps.scrollOffsetMax;
-    this.swipeThreshold =
-      this.props.swipeThreshold ?? defaultProps.swipeThreshold;
-    this.onModalShow = this.props.onModalShow ?? defaultProps.onModalShow;
-    this.onModalHide = this.props.onModalHide ?? defaultProps.onModalHide;
 
     if (this.state.isSwipeable) {
       this.state = {
@@ -375,8 +358,12 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           // For reference:
           // https://github.com/react-native-community/react-native-modal/pull/197
           const shouldSetPanResponder =
-            Math.abs(gestureState.dx) >= this.panResponderThreshold ||
-            Math.abs(gestureState.dy) >= this.panResponderThreshold;
+            Math.abs(gestureState.dx) >=
+              (this.props.panResponderThreshold ??
+                defaultProps.panResponderThreshold) ||
+            Math.abs(gestureState.dy) >=
+              (this.props.panResponderThreshold ??
+                defaultProps.panResponderThreshold);
           if (shouldSetPanResponder && this.props.onSwipeStart) {
             this.props.onSwipeStart(gestureState);
           }
@@ -399,7 +386,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           hasScrollableView &&
           this.shouldPropagateSwipe(e, gestureState) &&
           this.props.scrollTo &&
-          this.scrollOffset > 0
+          (this.props.scrollOffset ?? defaultProps.scrollOffset) > 0
         ) {
           return false; // user needs to be able to scroll content back up
         }
@@ -445,15 +432,29 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (this.props.scrollTo) {
             if (this.props.scrollHorizontal) {
               let offsetX = -gestureState.dx;
-              if (offsetX > this.scrollOffsetMax) {
-                offsetX -= (offsetX - this.scrollOffsetMax) / 2;
+              if (
+                offsetX >
+                (this.props.scrollOffsetMax ?? defaultProps.scrollOffsetMax)
+              ) {
+                offsetX -=
+                  (offsetX -
+                    (this.props.scrollOffsetMax ??
+                      defaultProps.scrollOffsetMax)) /
+                  2;
               }
 
               this.props.scrollTo({x: offsetX, animated: false});
             } else {
               let offsetY = -gestureState.dy;
-              if (offsetY > this.scrollOffsetMax) {
-                offsetY -= (offsetY - this.scrollOffsetMax) / 2;
+              if (
+                offsetY >
+                (this.props.scrollOffsetMax ?? defaultProps.scrollOffsetMax)
+              ) {
+                offsetY -=
+                  (offsetY -
+                    (this.props.scrollOffsetMax ??
+                      defaultProps.scrollOffsetMax)) /
+                  2;
               }
 
               this.props.scrollTo({y: offsetY, animated: false});
@@ -465,7 +466,8 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         // Call the onSwipe prop if the threshold has been exceeded on the right direction
         const accDistance = this.getAccDistancePerDirection(gestureState);
         if (
-          accDistance > this.swipeThreshold &&
+          accDistance >
+            (this.props.swipeThreshold ?? defaultProps.swipeThreshold) &&
           this.isSwipeDirectionAllowed(gestureState)
         ) {
           if (this.props.onSwipeComplete) {
@@ -504,7 +506,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         }).start();
 
         if (this.props.scrollTo) {
-          if (this.scrollOffset > this.scrollOffsetMax) {
+          if (
+            (this.props.scrollOffset ?? defaultProps.scrollOffset) >
+            (this.props.scrollOffsetMax ?? defaultProps.scrollOffsetMax)
+          ) {
             this.props.scrollTo({
               y: this.props.scrollOffsetMax,
               animated: true,
@@ -661,7 +666,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (!this.props.isVisible) {
             this.close();
           } else {
-            this.onModalShow();
+            this.props.onModalShow!();
           }
         });
     }
@@ -715,7 +720,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
                     isVisible: false,
                   },
                   () => {
-                    this.onModalHide();
+                    this.props.onModalHide!();
                   },
                 );
               },

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -77,12 +77,6 @@ const defaultProps = {
         gestureState: PanResponderGestureState,
       ) => boolean),
   isVisible: false,
-  onModalShow: () => null,
-  onModalWillShow: () => null,
-  onModalHide: () => null,
-  onModalWillHide: () => null,
-  onBackdropPress: () => null,
-  onBackButtonPress: () => null,
   panResponderThreshold: 4,
   swipeThreshold: 100,
 
@@ -114,12 +108,12 @@ export type ModalProps = ViewProps & {
   presentationStyle?: PresentationStyle;
 
   // Default ModalProps Provided
-  onModalShow: () => void;
-  onModalWillShow: () => void;
-  onModalHide: () => void;
-  onModalWillHide: () => void;
-  onBackdropPress: () => void;
-  onBackButtonPress: () => void;
+  onModalShow?: () => void;
+  onModalWillShow?: () => void;
+  onModalHide?: () => void;
+  onModalWillHide?: () => void;
+  onBackdropPress?: () => void;
+  onBackButtonPress?: () => void;
   useNativeDriverForBackdrop?: boolean;
 } & typeof defaultProps;
 
@@ -616,7 +610,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           if (!this.props.isVisible) {
             this.close();
           } else {
-            this.props.onModalShow();
+            this.props.onModalShow!();
           }
         });
     }
@@ -670,7 +664,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
                     isVisible: false,
                   },
                   () => {
-                    this.props.onModalHide();
+                    this.props.onModalHide!();
                   },
                 );
               },


### PR DESCRIPTION
# Overview
This fixes function props types. In my last PR (#567) I messed up with all functions props: using `() => null` in defaultProps and `() => void` in the interface made TypeScript compiled this as `(() => null & () => void)`, which is not the behavior we want.

To fix this, I had to change the defaultProps to `(() => null) as () => void`, so now the type is only `() => void | undefined`.

I'm sorry about this. I didn't realized until I upgraded my project to the latest version. I tested it now and its working as expected

# Test Plan

Only types changes