### PR TITLE
fix:  Add statusBarTranslucent prop back

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -90,6 +90,7 @@ const defaultProps = {
   scrollOffset: 0,
   scrollOffsetMax: 0,
   scrollHorizontal: false,
+  statusBarTranslucent: false,
   supportedOrientations: ['portrait', 'landscape'] as Orientation[],
 };
 


### PR DESCRIPTION
# Overview

In v12.0.0, the statusBarTranslucent prop was (accidentally?) removed. This PR simply puts it back. 