### PR TITLE
fix: fix scrolling of inner ScrollView or FlatList

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -353,14 +353,16 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
             /scrollview|flatlist/i.test(instance.type),
           );
 
-        if (
-          hasScrollableView &&
-          this.shouldPropagateSwipe(e, gestureState) &&
-          this.props.scrollTo &&
-          this.props.scrollOffset > 0
-        ) {
+        // when users scroll over inner scrollview/flatlist the modal shouldn't responses
+        // if propagateSwipe is set
+        if (hasScrollableView && this.shouldPropagateSwipe(e, gestureState)) {
+          return false
+        }
+
+        if (this.props.scrollTo && this.props.scrollOffset > 0) {
           return false; // user needs to be able to scroll content back up
         }
+
         if (this.props.onSwipeStart) {
           this.props.onSwipeStart(gestureState);
         }


### PR DESCRIPTION
# Overview
Hey guys! First of all thanks for working on this library. Appreciate that 🙏

By this PR I am trying to fix the scrolling of inner FlatList. My specific use case is having a horizontal FlatList at bottom of the modal and I want the rest of the modal to respond on swiping down (see attached videos please).

This is related to https://github.com/react-native-modal/react-native-modal/issues/236 specifically fixes what is written in this comment https://github.com/react-native-modal/react-native-modal/issues/236#issuecomment-854590475.

I also don't understand why we check `scrollTo` and `scrllOffset` together with `hasScrollableView` and `propageSwipe` props. So I just separated them. Maybe I am wrong. Let me know if there is a reason for that, please.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan
### This is a current situation
We can't scroll with inner horizontal FlatList. Note that any `swipeDirection` causing the same behaviour.

https://user-images.githubusercontent.com/3531955/128475979-aaa9d123-77bb-4a40-88ed-0300fccf127d.mov

### After the fix

https://user-images.githubusercontent.com/3531955/128476148-9064c21d-2f33-41c1-b715-292e6ab4c208.mov


<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
