### PR TITLE
Make `deviceWidth` and `deviceHeight` to also accept number

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -67,8 +67,8 @@ const defaultProps = {
   backdropTransitionOutTiming: 300,
   customBackdrop: null as React.ReactNode,
   useNativeDriver: false,
-  deviceHeight: null,
-  deviceWidth: null,
+  deviceHeight: null as OrNull<number>,
+  deviceWidth: null as OrNull<number>,
   hideModalContentWhileAnimating: false,
   propagateSwipe: false as
     | boolean


### PR DESCRIPTION
Signed-off-by: Egi Ginting <exneval.rayz@gmail.com>

# Overview

Follow up PR #567 
Fix deviceWidth and deviceHeight prop types to also accept number #583 

# Test Plan

This fixes only TypeScript interfaces, so should not change the component default behavior.
