### PR TITLE
major: remove deprecated function removeListener

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "^0.65.0"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "^0.65.0"
+    "react-native": ">=0.65.0"
   },
   "jest": {
     "preset": "react-native"

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   DeviceEventEmitter,
   Dimensions,
+  EmitterSubscription,
   InteractionManager,
   KeyboardAvoidingView,
   Modal,
@@ -202,6 +203,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   backdropRef: any;
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
+  didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
 
   interactionHandle: OrNull<number> = null;
 
@@ -243,7 +245,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
         '`<Modal onSwipe="..." />` is deprecated and will be removed starting from 13.0.0. Use `<Modal onSwipeComplete="..." />` instead.',
       );
     }
-    DeviceEventEmitter.addListener(
+    this.didUpdateDimensionsEmitter = DeviceEventEmitter.addListener(
       'didUpdateDimensions',
       this.handleDimensionsUpdate,
     );
@@ -258,10 +260,9 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
       'hardwareBackPress',
       this.onBackButtonPress,
     );
-    DeviceEventEmitter.removeListener(
-      'didUpdateDimensions',
-      this.handleDimensionsUpdate,
-    );
+    if (this.didUpdateDimensionsEmitter) {
+      this.didUpdateDimensionsEmitter.remove();
+    }
     if (this.interactionHandle) {
       InteractionManager.clearInteractionHandle(this.interactionHandle);
       this.interactionHandle = null;


### PR DESCRIPTION
# Overview

See this issue: https://github.com/react-native-modal/react-native-modal/issues/588

Following the upgrade to react-native 0.65.0 and the deprecation of `DeviceEventEmitter.removeListener` in favor of `.remove()`.
 
# Test Plan

I have patched-package the same code on our project with success but if you can test on your side as well, that would be nice.