### PR TITLE
removed removeEventListener, used in BackHandler.

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -203,7 +203,8 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   backdropRef: any;
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
-  didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
+  didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null
+  backButtonHandler: OrNull<EmitterSubscription> = null
 
   interactionHandle: OrNull<number> = null;
 
@@ -252,14 +253,13 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     if (this.state.isVisible) {
       this.open();
     }
-    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+     this.backButtonHandler = BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
   }
 
   componentWillUnmount() {
-    BackHandler.addEventListener(
-      'hardwareBackPress',
-      this.onBackButtonPress,
-    )?.remove();
+    if(this.backButtonHandler){
+      this.backButtonHandler?.remove();
+    }
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
     }

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -256,10 +256,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   }
 
   componentWillUnmount() {
-    BackHandler.removeEventListener(
+    BackHandler.addEventListener(
       'hardwareBackPress',
       this.onBackButtonPress,
-    );
+    )?.remove();
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
     }

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -203,8 +203,8 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   backdropRef: any;
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
-  didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null
-  backButtonHandler: OrNull<EmitterSubscription> = null
+  didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
+  backButtonHandler: OrNull<EmitterSubscription> = null;
 
   interactionHandle: OrNull<number> = null;
 


### PR DESCRIPTION
# Overview
There is still a **removeEventListener** used in **BackHandler**, which is throwing error/warning in RN 0.65.1.
