### PR TITLE
Make default props optional in type definition

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -117,7 +117,7 @@ export type ModalProps = ViewProps & {
 
   // Default ModalProps Provided
   useNativeDriverForBackdrop?: boolean;
-} & typeof defaultProps;
+} & Partial<typeof defaultProps>;
 
 const extractAnimationFromProps = (props: ModalProps) => ({
   animationIn: props.animationIn,


### PR DESCRIPTION
# Overview

this helps in unnecessary typescript errors while creating a wrapper component

# Test Plan
suppose we create a warpper for modal component with app specific default props like below
```tsx
import OModal, {ModalProps} from "react-native-modal";

export default function Modal(props: ModalProps) {
	return <OModal hideModalContentWhileAnimating={true} {...props} />;
}
```
you will see typescript error "TS2783: 'hideModalContentWhileAnimating' is specified more than once, so this usage will be overwritten."
when you use component with optional call backs from parent like below `this.props.onModalShow` is optional
```tsx
<Modal 
   isVisible={this.state.show}
   onModalShow={this.props.onModalShow}>
```
you will see typescript error "TS2322: Type '(() => void) | undefined' is not assignable to type '() => void'.   Type 'undefined' is not assignable to type '() => void'."