### PR TITLE
fix: make getDerivedStateFromProps's nextProps param Readonly

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -232,7 +232,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     }
   }
 
-  static getDerivedStateFromProps(nextProps: ModalProps, state: State) {
+  static getDerivedStateFromProps(nextProps: Readonly<ModalProps>, state: State) {
     if (!state.isVisible && nextProps.isVisible) {
       return {isVisible: true, showContent: true};
     }


### PR DESCRIPTION
# Overview

Fixes #381.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
