### PR TITLE
chore: fixed an issue that prevented apple m1 machines from successfu…

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -51,3 +51,24 @@ target 'ModalExample-tvOS' do
   end
 
 end
+
+post_install do |installer|
+  ## Fix for XCode 12.5
+      find_and_replace("../node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm",
+      "_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules", "_initializeModules:(NSArray<Class> *)modules")
+      find_and_replace("../node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm",
+      "RCTBridgeModuleNameForClass(module))", "RCTBridgeModuleNameForClass(Class(module)))")
+  end
+
+def find_and_replace(dir, findstr, replacestr)
+  Dir[dir].each do |name|
+      text = File.read(name)
+      replace = text.gsub(findstr,replacestr)
+      if text != replace
+          puts "Fix: " + name
+          File.open(name, "w") { |file| file.puts replace }
+          STDOUT.flush
+      end
+  end
+  Dir[dir + '*/'].each(&method(:find_and_replace))
+end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -259,7 +259,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - boost-for-react-native
 
 EXTERNAL SOURCES:
@@ -351,6 +351,6 @@ SPEC CHECKSUMS:
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
-PODFILE CHECKSUM: a8bf055ae8ec2f8beb6bcaba01898acbef0a62b1
+PODFILE CHECKSUM: e843afc29e7b90a90d1862276b80f2b0b99a259f
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.11.2


### PR DESCRIPTION
…lly building the example

# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->

I was unable to run e2e tests with detox. I continue to get errors with detox and am unsure how to resolve them. I was having issues pulling and building the project in Xcode 13.2.1 so I added some code to the Podfile to fix the issue. If you have any info on getting detox to run successfully while running yarn install would be appreciated. I am on a new MacBook Pro M1 pro machine. 

Thanks!
