### PR TITLE
fix: fix exception due to deprecated removeEventListener on RN 70.X

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -17,6 +17,7 @@ import {
   View,
   ViewStyle,
   ViewProps,
+  NativeEventSubscription,
 } from 'react-native';
 import * as PropTypes from 'prop-types';
 import * as animatable from 'react-native-animatable';
@@ -204,6 +205,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
   didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
+  hardwareBackPressEmitter: OrNull<NativeEventSubscription> = null;
 
   interactionHandle: OrNull<number> = null;
 
@@ -232,7 +234,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     }
   }
 
-  static getDerivedStateFromProps(nextProps: Readonly<ModalProps>, state: State) {
+  static getDerivedStateFromProps(
+    nextProps: Readonly<ModalProps>,
+    state: State,
+  ) {
     if (!state.isVisible && nextProps.isVisible) {
       return {isVisible: true, showContent: true};
     }
@@ -252,16 +257,18 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     if (this.state.isVisible) {
       this.open();
     }
-    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
-  }
-
-  componentWillUnmount() {
-    BackHandler.removeEventListener(
+    this.hardwareBackPressEmitter = BackHandler.addEventListener(
       'hardwareBackPress',
       this.onBackButtonPress,
     );
+  }
+
+  componentWillUnmount() {
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
+    }
+    if (this.hardwareBackPressEmitter) {
+      this.hardwareBackPressEmitter.remove();
     }
     if (this.interactionHandle) {
       InteractionManager.clearInteractionHandle(this.interactionHandle);


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

* This should fix the exception caused due to `removeEventListener` being deprecated in the newer RN versions, rendering the library to not be used on the projects using latest RN version

# Test Plan

* Need some help here, do not exactly know how to test the changes, but on our product, when I did the similar change we did not face any crashes due to exception

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
