### PR TITLE
Fixed onModalHide being called early

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -682,7 +682,14 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
                     isVisible: false,
                   },
                   () => {
-                    this.props.onModalHide();
+                    // Delay onModalHide by 2 cycles to ensure that:
+                    // 1. RN ModalContent has been unmounted
+                    // 2. RN ModalFocusTrap has been executed and no longer active
+                    this.setState({}, () => {
+                      this.setState({}, () => {
+                        this.props.onModalHide();
+                      });
+                    });
                   },
                 );
               },


### PR DESCRIPTION
# Overview
The `onModalHide` is being called too early (i.e. before actually hiding the modal) and if we try to focus an element on that callback it will fail due to RN [focus trap](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js).

Unfortunately there is no easy way to know when the modal has been hidden (RN does not have `onHide` prop). But I found that we can fix this be delaying the callback by 2 cycles, first one to ensure that the modal content has been unmounted and the second to ensure that the focus trap is no longer active (after [refocusing the element that triggered opening the modal](https://github.com/Expensify/react-native-web/blob/e9b7517663f996e123772b0047a6db3415ed59da/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js#L144-L156)).

# Test Plan
Consider the example stated above where we try to focus an element `onModalHide` callback.

| Before | After |
|--------|-------|
|  <video src="https://user-images.githubusercontent.com/16493223/218310849-273587f2-551b-45cc-ace6-98f8eefddf4b.mp4" /> |  <video src="https://user-images.githubusercontent.com/16493223/218310874-38b1d694-2f13-4d52-99a7-07944d15471f.mp4" />    |




