### PR TITLE
feature: add onModalMount callback function

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -81,6 +81,7 @@ const defaultProps = {
   panResponderThreshold: 4,
   swipeThreshold: 100,
 
+  onModalMount: (() => null) as () => void,
   onModalShow: (() => null) as () => void,
   onModalWillShow: (() => null) as () => void,
   onModalHide: (() => null) as () => void,
@@ -144,6 +145,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     isVisible: PropTypes.bool.isRequired,
     hideModalContentWhileAnimating: PropTypes.bool,
     propagateSwipe: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    onModalMount: PropTypes.func,
     onModalShow: PropTypes.func,
     onModalWillShow: PropTypes.func,
     onModalHide: PropTypes.func,
@@ -253,6 +255,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
       this.open();
     }
     BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+    this.props.onModalMount?.();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
# Overview

This is a needed callback function to notify component using RNModal that it's mounted and ready to be show the modal.

Sometimes RNModal is not ready yet, when app has just been loaded. So, if the call to render(isVisible => true) comes too early, RNModal stays stuck without showing any modal.

