### PR TITLE
fix BackHandler removeEventListener to use new subscription removal s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-modal",
-  "version": "13.0.1",
+  "version": "14.0.0",
   "description": "An enhanced React Native modal",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "react-native-animatable": "1.3.3"
+    "react-native-animatable": "1.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.65.0"
+    "react-native": ">=0.69.0"
   },
   "jest": {
     "preset": "react-native"

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -3,7 +3,6 @@ import {
   Animated,
   DeviceEventEmitter,
   Dimensions,
-  EmitterSubscription,
   InteractionManager,
   KeyboardAvoidingView,
   Modal,
@@ -17,6 +16,8 @@ import {
   View,
   ViewStyle,
   ViewProps,
+  EmitterSubscription,
+  NativeEventSubscription,
 } from 'react-native';
 import * as PropTypes from 'prop-types';
 import * as animatable from 'react-native-animatable';
@@ -204,6 +205,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
   contentRef: any;
   panResponder: OrNull<PanResponderInstance> = null;
   didUpdateDimensionsEmitter: OrNull<EmitterSubscription> = null;
+  backHandlerEventSubscription: OrNull<NativeEventSubscription> = null;
 
   interactionHandle: OrNull<number> = null;
 
@@ -232,7 +234,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     }
   }
 
-  static getDerivedStateFromProps(nextProps: Readonly<ModalProps>, state: State) {
+  static getDerivedStateFromProps(
+    nextProps: Readonly<ModalProps>,
+    state: State,
+  ) {
     if (!state.isVisible && nextProps.isVisible) {
       return {isVisible: true, showContent: true};
     }
@@ -252,14 +257,16 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     if (this.state.isVisible) {
       this.open();
     }
-    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
-  }
-
-  componentWillUnmount() {
-    BackHandler.removeEventListener(
+    this.backHandlerEventSubscription = BackHandler.addEventListener(
       'hardwareBackPress',
       this.onBackButtonPress,
     );
+  }
+
+  componentWillUnmount() {
+    if (this.backHandlerEventSubscription) {
+      this.backHandlerEventSubscription.remove();
+    }
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
     }


### PR DESCRIPTION
…yntax

# Overview

On a react-native version >= 0.69 the `removeEventListener` on `BackHandler` now much use the subscription removal syntax. Small refactor to use `.remove()`

# Test Plan

Using this is my company's code base. Need this for a major upgrade to `react-native`