### PR TITLE
Fix: Prevent backdrop flicker when closing modal

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -232,7 +232,10 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     }
   }
 
-  static getDerivedStateFromProps(nextProps: Readonly<ModalProps>, state: State) {
+  static getDerivedStateFromProps(
+    nextProps: Readonly<ModalProps>,
+    state: State,
+  ) {
     if (!state.isVisible && nextProps.isVisible) {
       return {isVisible: true, showContent: true};
     }
@@ -720,6 +723,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
           this.state.showContent && !hasCustomBackdrop
             ? backdropColor
             : 'transparent',
+        opacity: this.props.backdropOpacity,
       },
     ];
 


### PR DESCRIPTION
Added explicit setting of backdrop opacity to ensure consistent opacity during the modal's lifecycle. Prevents backdrop flickering when closing the modal.

Credit goes to [Milker90](https://github.com/Milker90) in this [comment](https://github.com/react-native-modal/react-native-modal/issues/734#issuecomment-2495238723). 

# Overview

Fixes the known issue reported multiple times for both iOS and Android, where the backdrop flickers as you close the modal. Other recommendations do not fix the issue (set `hideModalContentWhileAnimating` true for example).

# Test Plan

Current version `13.0.1`:
https://github.com/user-attachments/assets/354defb0-e7d5-400b-9c71-fe53758138ee

After the fix:
https://github.com/user-attachments/assets/0ed92b21-3592-431e-8983-82ecce688d54

