### PR TITLE
Update modal.tsx

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -252,14 +252,14 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
     if (this.state.isVisible) {
       this.open();
     }
-    BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+  //  BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
   }
 
   componentWillUnmount() {
-    BackHandler.removeEventListener(
+  /*  BackHandler.removeEventListener(
       'hardwareBackPress',
       this.onBackButtonPress,
-    );
+    ); */
     if (this.didUpdateDimensionsEmitter) {
       this.didUpdateDimensionsEmitter.remove();
     }


### PR DESCRIPTION
In react native 0.78 new version the hardwareBackPress Event has been removed, so that's reason when you press the on back button, the modal create issue in BackHandler.removeEventListener, so the solution of this issues is just comment these lines or remove these lines, so that issue is solved in react native 0.78 new version
![Screenshot 2025-02-26 010440](https://github.com/user-attachments/assets/ede921dd-a49b-4539-9420-eb8dd60c9975)


# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! -->
