### PR TITLE
fix crash rn 79: mixin Animated.Value & primitive seems to cause crash

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -706,6 +706,9 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
       </TouchableWithoutFeedback>
     );
   };
+
+  private stableAnimatedValueZero = new Animated.Value(0);
+
   render() {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
@@ -733,7 +736,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     const { testID, ...containerProps } = otherProps;
     const computedStyle = [
-      { margin: this.getDeviceWidth() * 0.05, transform: [{ translateY: 0 }] },
+      { margin: this.getDeviceWidth() * 0.05, transform: [{ translateY: this.stableAnimatedValueZero }] },
       styles.content,
       style,
     ];


### PR DESCRIPTION
`react-native-modal` crash with latest react-native version (0.79) because somehow we're not allowed to mix `transform` object using primitive value and Animated.Value at the same time...

I'll open an issue on react-native and will link the issue when it's ready.
Meanwhile, since a lot of people will try to migrate to expo 53 (rn-79) I think it is legit to fix the issue here and not wait for react-native to solve the real underlying issue.

linked issue https://github.com/react-native-modal/react-native-modal/issues/793